### PR TITLE
feat: Update lints set to the newer version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.2.0
+* Remove `always_require_non_null_named_parameters` due to deprecation
+* Remove `avoid_returning_null` due to deprecation
+* Remove `avoid_returning_null_for_future` due to deprecation
+* Remove `prefer_equal_for_default_values` due to deprecation
+* Add `unnecessary_breaks` new rule
+
 ## 1.1.0
 * `omit_local_variable_types: false`
 * `unnecessary_lambdas: false`

--- a/lib/all_lint_rules.yaml
+++ b/lib/all_lint_rules.yaml
@@ -3,7 +3,6 @@ linter:
     - always_declare_return_types
     - always_put_control_body_on_new_line
     - always_put_required_named_parameters_first
-    - always_require_non_null_named_parameters
     - always_specify_types
     - always_use_package_imports
     - annotate_overrides
@@ -32,8 +31,6 @@ linter:
     - avoid_relative_lib_imports
     - avoid_renaming_method_parameters
     - avoid_return_types_on_setters
-    - avoid_returning_null
-    - avoid_returning_null_for_future
     - avoid_returning_null_for_void
     - avoid_returning_this
     - avoid_setters_without_getters
@@ -121,7 +118,6 @@ linter:
     - prefer_constructors_over_static_methods
     - prefer_contains
     - prefer_double_quotes
-    - prefer_equal_for_default_values
     - prefer_expression_function_bodies
     - prefer_final_fields
     - prefer_final_in_for_each
@@ -169,6 +165,7 @@ linter:
     - unawaited_futures
     - unnecessary_await_in_return
     - unnecessary_brace_in_string_interps
+    - unnecessary_breaks
     - unnecessary_const
     - unnecessary_constructor_name
     - unnecessary_final

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: linteo
 description: Flutter and Dart lint rules used at iteo
-version: 1.1.0
+version: 1.2.0
 
 repository: https://github.com/Iteo/linteo
 issue_tracker: https://github.com/Iteo/linteo/issues


### PR DESCRIPTION
Updated `all_lint_rules.yaml` according to the new version of [an official auto-generated lints list](https://dart-lang.github.io/linter/lints/options/options.html).