### PR TITLE
feat: Update lints set to newer version and upgrade sdk constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,21 @@
+## 1.3.0
+
+* Add `annotate_redeclares` new experimental rule
+* Add `deprecated_member_use_from_same_package` new rule
+* Remove `enable_null_safety` due to the removal of the rule from all linter rules
+* Add `implicit_reopen` new experimental rule
+* Add `invalid_case_patterns` new experimental rule
+* Remove `iterable_contains_unrelated_type` due to deprecation
+* Remove `list_remove_unrelated_type` due to deprecation
+* Add `matching_super_parameters` new rule
+* Add `no_literal_bool_comparisons` new rule
+* Add `no_self_assignments` new rule
+* Add `no_wildcard_variable_uses` new rule
+* Add `type_literal_in_constant_pattern` new rule
+* Upgrade required Dart SDK to 3.1.0
+
 ## 1.2.0
+
 * Remove `always_require_non_null_named_parameters` due to deprecation
 * Remove `avoid_returning_null` due to deprecation
 * Remove `avoid_returning_null_for_future` due to deprecation
@@ -6,6 +23,7 @@
 * Add `unnecessary_breaks` new rule
 
 ## 1.1.0
+
 * `omit_local_variable_types: false`
 * `unnecessary_lambdas: false`
 * `avoid_implementing_value_types: false`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Add `no_literal_bool_comparisons` new rule
 * Add `no_self_assignments` new rule
 * Add `no_wildcard_variable_uses` new rule
+* Add `flutter_style_todos` existing role unlocked
 * Add `type_literal_in_constant_pattern` new rule
 * Upgrade required Dart SDK to 3.1.0
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ Provides set of Flutter and Dart linter rules used at [iteo]. By default, packag
 1. Depend on this package as a dev_dependency by running `flutter pub add --dev linteo`
 2. Create `analysis_options.yaml` file at the root of the package (alongside the pubspec.yaml file) and include: `package:linteo/analysis_options.yaml` from it.
 
+
+## Which version to use?
+
+| Dart Version | Linteo Version                                                            |
+|--------------|-------------------------------------------------------------------------|
+| `3.1`        | [`1.3.0`](https://pub.dev/packages/linteo/versions/1.3.0/changelog)|
+| `2.17`       | [`1.2.0`](https://pub.dev/packages/linteo/versions/1.2.0/changelog)|
+| `2.17`       | [`1.1.0`](https://pub.dev/packages/linteo/versions/1.1.0/changelog)|
+| `2.17`       | [`1.0.1`](https://pub.dev/packages/linteo/versions/1.1.0/changelog)|
+| `2.18`       | [`1.0.0`](https://pub.dev/packages/linteo/versions/1.0.0/changelog)|
+    
+
 ### **Example** `analysis_options.yaml` file
 
 ```yaml

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,6 +7,6 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.1.0"
+    version: "1.3.0"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=3.1.0 <4.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,7 @@ version: 0.0.1
 publish_to: none
 
 environment:
-  sdk: ">=2.18.0 <3.0.0"
+  sdk: ">=3.1.0 <4.0.0"
 
 dev_dependencies:
   linteo:

--- a/lib/all_lint_rules.yaml
+++ b/lib/all_lint_rules.yaml
@@ -6,6 +6,7 @@ linter:
     - always_specify_types
     - always_use_package_imports
     - annotate_overrides
+    - annotate_redeclares
     - avoid_annotating_with_dynamic
     - avoid_bool_literals_in_conditional_expressions
     - avoid_catches_without_on_clauses
@@ -61,6 +62,7 @@ linter:
     - dangling_library_doc_comments
     - depend_on_referenced_packages
     - deprecated_consistency
+    - deprecated_member_use_from_same_package
     - diagnostic_describe_all_properties
     - directives_ordering
     - discarded_futures
@@ -68,7 +70,6 @@ linter:
     - empty_catches
     - empty_constructor_bodies
     - empty_statements
-    - enable_null_safety
     - eol_at_end_of_file
     - exhaustive_cases
     - file_names
@@ -76,7 +77,8 @@ linter:
     - hash_and_equals
     - implementation_imports
     - implicit_call_tearoffs
-    - iterable_contains_unrelated_type
+    - implicit_reopen
+    - invalid_case_patterns
     - join_return_with_assignment
     - leading_newlines_in_multiline_strings
     - library_annotations
@@ -84,16 +86,19 @@ linter:
     - library_prefixes
     - library_private_types_in_public_api
     - lines_longer_than_80_chars
-    - list_remove_unrelated_type
     - literal_only_boolean_expressions
+    - matching_super_parameters
     - missing_whitespace_between_adjacent_strings
     - no_adjacent_strings_in_list
     - no_default_cases
     - no_duplicate_case_values
     - no_leading_underscores_for_library_prefixes
     - no_leading_underscores_for_local_identifiers
+    - no_literal_bool_comparisons
     - no_logic_in_create_state
     - no_runtimeType_toString
+    - no_self_assignments
+    - no_wildcard_variable_uses
     - non_constant_identifier_names
     - noop_primitive_operations
     - null_check_on_nullable_type_parameter
@@ -162,6 +167,7 @@ linter:
     - tighten_type_of_initializing_formals
     - type_annotate_public_apis
     - type_init_formals
+    - type_literal_in_constant_pattern
     - unawaited_futures
     - unnecessary_await_in_return
     - unnecessary_brace_in_string_interps

--- a/lib/analysis_options.1.3.0.yaml
+++ b/lib/analysis_options.1.3.0.yaml
@@ -1,0 +1,158 @@
+include: all_lint_rules.yaml
+
+analyzer:
+  # For more information see:
+  # https://dart.dev/guides/language/analysis-options#enabling-additional-type-checks
+  language:
+    strict-casts: true
+    strict-inference: true
+    strict-raw-types: true
+
+  # Common generated files
+  exclude:
+    - "**/*.g.dart"
+    - "**/*.gr.dart"
+    - "**/*.freezed.dart"
+    - "**/*.config.dart"
+    - "**/*.cached.dart"
+    - "test/.test_coverage.dart"
+    - "lib/generated_plugin_registrant.dart"
+
+  errors:
+    # Without ignore here, we cause import of all_lint_rules to warn, because some rules conflict.
+    # We explicitly enabled even conflicting rules and are fixing the conflicts in this file.
+    included_file_warning: ignore
+    # Treat missing required parameters as an error.
+    missing_required_param: error
+    # Treat missing returns as an error, not as a hint or a warning.
+    missing_return: error
+    # Treat assigning new values to a parameter as a warning.
+    parameter_assignments: warning
+    # Allow having TODOs in the code.
+    todo: ignore
+
+linter:
+  rules:
+
+    # Experimental and disabled in other linters.
+    annotate_redeclares: false
+    
+    # Should not be enabled when the Dart formatter is used.
+    always_put_control_body_on_new_line: false
+    
+    # Unnecessary force to specify type when declaring local variable
+    always_specify_types: false
+    
+    # This should be project-dependent decisssion.
+    avoid_catches_without_on_clauses: false
+    
+    # Conflicts with: type_annotate_public_apis
+    avoid_annotating_with_dynamic: false
+    
+    # Allow to define AppColors, AppTypography classes
+    avoid_classes_with_only_static_members: false
+    
+    # Requires meta dependency
+    avoid_equals_and_hash_code_on_mutable_classes: false
+    
+    # Give more flexibility to define parameters as final or not
+    avoid_final_parameters: false
+    
+    # Raises in tests' mock
+    avoid_implementing_value_types: false
+    
+    # It is often quicker when dealing with not well known APIs
+    # to see parameter values in the call/constructor,
+    avoid_redundant_argument_values: false
+    
+    # Unnecessary force
+    avoid_returning_this: false
+    
+    # Allow to specify public setter and do not expose getter
+    avoid_setters_without_getters: false
+    
+    # Allows to create Widget with parameters for future improvements
+    avoid_unused_constructor_parameters: false
+    
+    # Give more flexibility when defining lambda (Generic<T> t) => someOperation(t)
+    avoid_types_on_closure_parameters: false
+    
+    # More flexibility if developer preffers cascase or sequental call
+    cascade_invocations: false
+    
+    # Conflict with cubit initializers
+    discarded_futures: false
+    
+    # Not necessary in Flutter Widgets
+    diagnostic_describe_all_properties: false
+    
+    # Allow pass configuration to an app
+    do_not_use_environment: false
+    
+    # Unnecessary explicit of Callable classes
+    implicit_call_tearoffs: false
+    
+    # In some cases affects readability (e.g. Singleton definition)
+    join_return_with_assignment: false
+    
+    # In general stick to 80 characters, but allow SomeVeryLongCamelCaseClass
+    lines_longer_than_80_chars: false
+    
+    # Too restrictive
+    missing_whitespace_between_adjacent_strings: false
+    
+    # Give developer more flexibility if should define local types or not
+    omit_local_variable_types: false
+    
+    # Allow define abstract class with only one method
+    one_member_abstracts: false
+    
+    # Too verbose documentation
+    package_api_docs: false
+    
+    # Null checks don't need a message
+    prefer_asserts_with_message: false
+    
+    # Prefer single quotes instead
+    prefer_double_quotes: false
+    
+    # Not quite suitable for Flutter, which may have a `build` method with a single return,
+    # but that return is still complex enough that a "body" is worth it.
+    prefer_expression_function_bodies: false
+    
+    # forEach performance
+    prefer_foreach: false
+    
+    # Incompatible with DI package
+    prefer_final_parameters: false
+    
+    # Weird syntax: double x = 8
+    prefer_int_literals: false
+    
+    # Team decided to keep package imports
+    prefer_relative_imports: false
+    
+    # Unnecessary documentation for Widgets
+    public_member_api_docs: false
+    
+    # This rule enforces the local var style, which we don't like
+    unnecessary_final: false
+    
+    # https://github.com/dart-lang/language/issues/870
+    unnecessary_await_in_return: false
+    
+    # Does not respect types. If satisfied: code does not compile
+    unnecessary_lambdas: false
+    
+    # We don't want to force Java-style enums
+    use_enums: false
+    
+    # Team decided to have more flexibility
+    use_if_null_to_convert_nulls_to_bools: false
+    
+    # Do not enforce setters
+    use_setters_to_change_properties: false
+    
+    # Too restrictive in terms of method naming
+    use_to_and_as_if_applicable: false
+        

--- a/lib/analysis_options.yaml
+++ b/lib/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: package:linteo/analysis_options.1.1.0.yaml
+include: package:linteo/analysis_options.1.3.0.yaml

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: linteo
 description: Flutter and Dart lint rules used at iteo
-version: 1.2.0
+version: 1.3.0
 
 repository: https://github.com/Iteo/linteo
 issue_tracker: https://github.com/Iteo/linteo/issues
@@ -8,4 +8,4 @@ homepage: https://github.com/Iteo/linteo
 documentation: https://github.com/Iteo/linteo
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=3.1.0 <4.0.0"


### PR DESCRIPTION
1. Updated `all_lint_rules.yaml` according to the new version of [an official lints list](https://dart.dev/tools/linter-rules/all).
2. Upgraded sdk contraint to 3.1.0
3. Added new `analysis_options.1.3.0.yaml` file
4. Updated `README.md` by adding a table indicating the sdk constraint for the linteo versions